### PR TITLE
Return empty list instead of not found response

### DIFF
--- a/FormUp.Api/Features/v1/Workouts/WorkoutErrors.cs
+++ b/FormUp.Api/Features/v1/Workouts/WorkoutErrors.cs
@@ -25,7 +25,7 @@ public static class WorkoutErrors
     {
         return Error.NotFound(
             $"{FeaturePrefix}:UserNotFound",
-            $"User with Id {id} has no logged workouts."
+            $"User with Id {id} was not found."
         );
     }
 }

--- a/FormUp.Api/Features/v1/Workouts/WorkoutsService.cs
+++ b/FormUp.Api/Features/v1/Workouts/WorkoutsService.cs
@@ -78,16 +78,16 @@ internal class WorkoutsService : IWorkoutsService
         int take = Constants.List.DefaultPageSize,
         CancellationToken cancellationToken = default)
     {
-        var usersWorkouts = _context.Workouts
-            .Where(w => w.UserId == userId);
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.Uid == userId);
 
-        if (!usersWorkouts.Any())
+        if (user is null)
         {
-            _logger.LogError("User with ID {ID} has no logged workouts", userId);
+            _logger.LogError("User with ID {ID} was not found", userId);
             return WorkoutErrors.UserNotFound(userId);
         }
 
-        IList<WorkoutInfo> result = await usersWorkouts
+        IList<WorkoutInfo> result = await _context.Workouts
+            .Where(w => w.UserId == userId)
             .OrderByDescending(w => w.At)
             .Take(take)
             .Skip(skip)
@@ -103,7 +103,7 @@ internal class WorkoutsService : IWorkoutsService
             new ResponseMetaData(
                 result.Count,
                 take,
-                usersWorkouts.Count()));
+                result.Count()));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
When retrieving workouts for user. In case where user exists but has no workouts, server responds with 404. This behavior was fixed to return empty list for existing user withou workouts. 404 is now returned for when user doesnt exist at all.